### PR TITLE
Add citracer to the list of research tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,6 +587,7 @@ For experimental research, eLabFTW made a online labnote system: [eLabFTW](https
 * [Connected Papers](https://www.connectedpapers.com/): Visualise connected papers with support for node colours, size and distance from origin to distinguish whether a paper is useful and how related it is.
 * [Uncited](https://uncited.org): Keeping up with the literature.
 * [ODataMap](https://github.com/CherishChenCherish/odatamap) - Interactive map of global scientific research. Visualizes 250M+ papers across 7 knowledge continents with AI research assistant. [Demo](https://odatamap.cherishchen2510.workers.dev)
+* [citracer](https://github.com/marcpinet/citracer): Trace citation chains for any concept across research papers. Given a source PDF (or arXiv/DOI), recursively walks the citation graph and produces an interactive HTML visualization. Supports forward and reverse tracing.
 
 ### Get Yourself A Citable Code for Anything
 


### PR DESCRIPTION
Adds [citracer](https://github.com/marcpinet/citracer) to the "Investigate Papers" section.

citracer traces citation chains for any keyword across research papers. Given a source PDF (or DOI / URL), it parses the bibliography with GROBID, finds every occurrence of the keyword in the body, identifies cited references near each occurrence, downloads those papers, and recursively walks the resulting citation graph. The output is an interactive HTML page.

Resolves PDFs from 10+ sources: arXiv, OpenReview, Semantic Scholar, Sci-Hub, bioRxiv, SSRN, and more
